### PR TITLE
Switch tick, startTick and getCurrentTick() to double.

### DIFF
--- a/src/main/java/software/bernie/geckolib3/core/IAnimatableModel.java
+++ b/src/main/java/software/bernie/geckolib3/core/IAnimatableModel.java
@@ -7,9 +7,9 @@ import software.bernie.geckolib3.core.processor.IBone;
 
 public interface IAnimatableModel<E>
 {
-	default float getCurrentTick()
+	default double getCurrentTick()
 	{
-		return (System.nanoTime() / 1000000L / 50f);
+		return (System.nanoTime() / 1000000L / 50.0);
 	}
 
 	default void setLivingAnimations(E entity, Integer uniqueID)

--- a/src/main/java/software/bernie/geckolib3/core/manager/AnimationData.java
+++ b/src/main/java/software/bernie/geckolib3/core/manager/AnimationData.java
@@ -15,10 +15,10 @@ public class AnimationData
 {
 	private HashMap<IBone, BoneSnapshot> boneSnapshotCollection;
 	private HashMap<String, AnimationController> animationControllers = new HashMap<>();
-	public float tick;
+	public double tick;
 	public boolean isFirstTick = true;
 	private double resetTickLength = 30;
-	public Float startTick;
+	public Double startTick;
 	public Object ticker;
 	public boolean shouldPlayWhilePaused = false;
 


### PR DESCRIPTION
This fixes various precision problems.