### PR TITLE
IAnimationPredicate has only one type parameter now. huzzah

### DIFF
--- a/src/main/java/software/bernie/geckolib3/core/controller/AnimationController.java
+++ b/src/main/java/software/bernie/geckolib3/core/controller/AnimationController.java
@@ -83,14 +83,14 @@ public class AnimationController<T extends IAnimatable>
 	 * An AnimationPredicate is run every render frame for ever AnimationController. The "test" method is where you should change animations, stop animations, restart, etc.
 	 */
 	@FunctionalInterface
-	public interface IAnimationPredicate<P>
+	public interface IAnimationPredicate<P extends IAnimatable>
 	{
 		/**
 		 * An AnimationPredicate is run every render frame for ever AnimationController. The "test" method is where you should change animations, stop animations, restart, etc.
 		 *
-		 * @return TRUE if the animation should continue, FALSE if it should stop.
+		 * @return CONTINUE if the animation should continue, STOP if it should stop.
 		 */
-		<P extends IAnimatable> PlayState test(AnimationEvent<P> event);
+		PlayState test(AnimationEvent<P> event);
 	}
 
 	/**


### PR DESCRIPTION
works with all of the bundled examples, shouldn't break anything except for weirdos that use `IAnimationPredicate<X>` to test `Y`s

~~smh why did i have to do this~~