### PR TITLE
Minor PlayState Change

### DIFF
--- a/src/main/java/software/bernie/geckolib3/core/PlayState.java
+++ b/src/main/java/software/bernie/geckolib3/core/PlayState.java
@@ -1,5 +1,6 @@
 package software.bernie.geckolib3.core;
 
 public enum PlayState {
-	CONTINUE, STOP
+	CONTINUE(0),
+	STOP(1)
 }


### PR DESCRIPTION
It provides safer interoperability, especially since I'm working on making GeckoLib compatible with the Haxe programming language.

This small change will ensure that when the Haxe code is compiled into Java code, the reference to this enum is consistent with how it's defined in Java.